### PR TITLE
Feature/adding pathway checks

### DIFF
--- a/bin/bio/convert/copy_number_to_obs.pl
+++ b/bin/bio/convert/copy_number_to_obs.pl
@@ -10,8 +10,8 @@ use feature qw(say);
 use FindBin qw($Bin);
 use lib "$Bin/../../../lib/perl";
 
-use PGMLab qw(create_obs_file);
-use PGMLab::Bio qw(get_donor_ploidy get_reactome_ids_to_names_maps get_genes_in_pi_file get_sample_list get_copy_number_gene_states);
+use PGMLab qw(create_obs_file get_nodes_in_pi_file);
+use PGMLab::Bio qw(get_donor_ploidy get_reactome_ids_to_names_maps get_sample_list get_copy_number_gene_states);
 
 use Getopt::Euclid qw( :minimal_keys );
 
@@ -22,7 +22,7 @@ my $donor_ploidy = get_donor_ploidy($ARGV{'ploidy'});
 
 my ($entity_name_to_reactome_id, $reactome_id_to_entity_name) = get_reactome_ids_to_names_maps($ARGV{'db_id_to_name_mapping'});
 
-my $pi_genes = get_genes_in_pi_file($ARGV{'pi'});
+my $pi_genes = get_nodes_in_pi_file($ARGV{'pi'});
 
 my $sample_list = get_sample_list($ARGV{'sample_list'});
 

--- a/bin/bio/convert/gistic_to_obs.pl
+++ b/bin/bio/convert/gistic_to_obs.pl
@@ -9,15 +9,15 @@ use feature qw(say);
 use FindBin qw($Bin);
 use lib "$Bin/../../../lib/perl";
 
-use PGMLab qw(create_obs_file);
-use PGMLab::Bio qw(get_gistic_gene_states get_genes_in_pi_file get_reatome_ids_to_names_maps);
+use PGMLab qw(create_obs_file get_nodes_in_pi_file);
+use PGMLab::Bio qw(get_gistic_gene_states get_reatome_ids_to_names_maps);
 
 use Getopt::Euclid qw( :minimal_keys );
 
 use Data::Dumper;
 
 my ($entity_name_to_reactome_id, $reactome_id_to_entity_name) = get_rectome_ids_to_names_maps($ARGV{'db_id_to_name_mapping'});
-my $pi_genes = get_genes_in_pi_file($ARGV{'pairwise_interaction'});
+my $pi_genes = get_nodes_in_pi_file($ARGV{'pairwise_interaction'});
 my ($sample_gene_states, $sample_list) = get_gistic_gene_states($ARGV{'gistic'}, $entity_name_to_reactome_id, $pi_genes);
 
 create_obs_file($ARGV{'observation_file'}, $sample_gene_states, $sample_list);

--- a/bin/bio/convert/snv_to_obs.pl
+++ b/bin/bio/convert/snv_to_obs.pl
@@ -9,14 +9,14 @@ use feature qw(say);
 use FindBin qw($Bin);
 use lib "$Bin/../../../lib/perl";
 
-use PGMLab qw(create_obs_file);
-use PGMLab::Bio qw(get_reactome_ids_to_names_maps get_genes_in_pi_file get_samples_from_sample_file get_snv_sample_gene_state);
+use PGMLab qw(create_obs_file get_nodes_in_pi_file);
+use PGMLab::Bio qw(get_reactome_ids_to_names_maps get_samples_from_sample_file get_snv_sample_gene_state);
 
 use Getopt::Euclid qw( :minimal_keys );
 
 my ($entity_name_to_reactome_id, $reactome_id_to_entity_name) = get_reactome_ids_to_names_maps($ARGV{'db_id_to_name_mapping'});
 
-my $pi_genes = get_genes_in_pi_file($ARGV{'pi'});
+my $pi_genes = get_nodes_in_pi_file($ARGV{'pi'});
 
 my $sample_list = get_samples_from_sample_file($ARGV{'sample_list'});
 

--- a/bin/process_reactome_raw_pathways.pl
+++ b/bin/process_reactome_raw_pathways.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use autodie;
+use feature qw(say);
+use POSIX;
+
+use Data::Dumper;
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib/perl";
+
+use PGMLab qw(is_pi_DAG create_pi_file get_interactions_in_pi_file get_siblings_in_pi_file);
+use PGMLab::NetworkComponents qw(network_components);
+
+my $reactome_export_dir = $ARGV[0];
+$reactome_export_dir = $1 if($reactome_export_dir=~/(.*)\/$/); #remove trailing slash if exists
+
+my $reactome_pi_result_dir = $ARGV[1];
+$reactome_pi_result_dir = $1 if($reactome_pi_result_dir=~/(.*)\/$/);
+
+opendir(my $dir_h, $reactome_export_dir);
+my @tsv_files = grep(/\.tsv$/,readdir($dir_h));
+closedir($dir_h);
+
+foreach my $tsv_file (@tsv_files) {
+    my ($pathway_name, $extension) = split /\./, $tsv_file;
+    $tsv_file = "$reactome_export_dir/$tsv_file";
+    my $interactions = get_interactions_in_pi_file($tsv_file);
+    my $siblings = get_siblings_in_pi_file($tsv_file);
+    
+    my $member_groups = network_components($siblings);
+    
+    my %member_hash =();
+
+    my $member_group_id = 0;
+    foreach my $members (@{$member_groups}) {
+        $member_hash{"group_$member_group_id"} = $member_groups->[$member_group_id];
+        $member_group_id++;
+    }
+
+    my $member_group_index = 1;
+    foreach my $key (sort {$member_hash{$b} <=> $member_hash{$a}} keys %member_hash) {
+       my $members = $member_hash{$key};
+ 
+       my %member_interactions = ();
+       foreach my $node (@{$members}) {
+           $member_interactions{$node} = $interactions->{$node};
+       }   
+
+       my $filepath = "$reactome_pi_result_dir/$pathway_name";
+       $filepath .= "_$member_group_index" if ($member_group_index != 1);
+       $filepath .= ".pi";
+      
+       say $filepath;
+       my $is_a_dag = (is_pi_DAG(\%member_interactions))? "yes":"no";
+       say "DAG? $is_a_dag";
+
+       create_pi_file($filepath, \%member_interactions);
+
+       $member_group_index++;    
+    }
+
+}

--- a/bin/process_reactome_raw_pathways.pl
+++ b/bin/process_reactome_raw_pathways.pl
@@ -11,8 +11,12 @@ use Data::Dumper;
 use FindBin qw($Bin);
 use lib "$Bin/../lib/perl";
 
-use PGMLab qw(is_pi_DAG create_pi_file get_interactions_in_pi_file get_siblings_in_pi_file);
+use PGMLab qw(add_pseudo_nodes_to_interactions is_pi_DAG create_pi_file get_interactions_in_pi_file get_siblings_in_pi_file);
 use PGMLab::NetworkComponents qw(network_components);
+
+#USAGE perl process_reactome_raw_pathways.pl <input_directory> <output_directory>
+
+my $max_number_of_parents = 10;
 
 my $reactome_export_dir = $ARGV[0];
 $reactome_export_dir = $1 if($reactome_export_dir=~/(.*)\/$/); #remove trailing slash if exists
@@ -57,6 +61,7 @@ foreach my $tsv_file (@tsv_files) {
        my $is_a_dag = (is_pi_DAG(\%member_interactions))? "yes":"no";
        say "DAG? $is_a_dag";
 
+       add_pseudo_nodes_to_interactions(\%member_interactions, $max_number_of_parents);
        create_pi_file($filepath, \%member_interactions);
 
        $member_group_index++;    

--- a/bin/process_reactome_raw_pathways.pl
+++ b/bin/process_reactome_raw_pathways.pl
@@ -5,7 +5,6 @@ use warnings;
 
 use autodie;
 use feature qw(say);
-use POSIX;
 
 use Data::Dumper;
 

--- a/bin/remove_duplicate_edges.pl
+++ b/bin/remove_duplicate_edges.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use autodie;
+use feature qw(say);
+use POSIX;
+
+my $pi_file = $ARGV[0];
+
+open(my $fh, "<", $pi_file);
+
+#skip header
+<$fh>;<$fh>;
+
+my %child_to_parents;
+while (my $line = <$fh>) {
+    chomp $line;
+    my ($from, $to, $part_three, $part_four) = split /\t/, $line;
+    $child_to_parents{$to}{$from} = [$part_three, $part_four];
+}
+
+###output file
+
+my $number_of_interactions = 0;
+foreach my $child (keys %child_to_parents) {
+    $number_of_interactions += scalar( keys %{$child_to_parents{$child}});
+}
+
+say "$number_of_interactions\n";
+foreach my $child (keys %child_to_parents) {
+    foreach my $parent (keys %{$child_to_parents{$child}}) {
+        my @values = @{$child_to_parents{$child}{$parent}};
+        say "$parent\t$child\t".$values[0]."\t".$values[1];
+    }
+}

--- a/bin/split_nodes.pl
+++ b/bin/split_nodes.pl
@@ -7,60 +7,21 @@ use autodie;
 use feature qw(say);
 use POSIX;
 
-my $input_file = $ARGV[0];
+use FindBin qw($Bin);
+use lib "$Bin/../lib/perl";
+
+use PGMLab qw(add_pseudo_nodes_to_interactions get_interactions_in_pi_file create_pi_file);
+
+#USAGE: perl split_nodes.pl <input_file> <output_file>
+
+my $input_filepath = $ARGV[0];
+
+my $output_filepath = $ARGV[1];
 
 my $max_number_of_parents = 10;
 
-open(my $fh, "<", $input_file);
+my $interactions = get_interactions_in_pi_file($input_filepath);
 
-#skip header
-<$fh>;<$fh>;
+add_pseudo_nodes_to_interactions($interactions, $max_number_of_parents);
 
-my %child_to_parents;
-while (my $line = <$fh>) {
-    chomp $line;
-    my ($from, $to, $part_three, $part_four) = split /\t/, $line;
-    $child_to_parents{$to}{$from} = [$part_three, $part_four];
-}
-
-close($fh);
-
-my ($num_groups, $num_parents, $nodes_per_group, $node_index, $group_index);
-foreach my $child (keys %child_to_parents) {
-    my @parents = keys %{$child_to_parents{$child}};
-    $num_parents = scalar @parents;
-    if ($num_parents >= 10) {
-        $num_groups =  ceil($num_parents/$max_number_of_parents);
-        $nodes_per_group = ceil($num_parents/$num_groups);
-
-        $group_index = 1;
-        $node_index = 1;
-        foreach my $parent (@parents) {
-              if ($node_index > $nodes_per_group) {
-                   $node_index = 1;
-                   $group_index++;
-              }
-              my @node_data = @{$child_to_parents{$child}{$parent}};
-              $child_to_parents{"$child\_PSEUDONODE\_$group_index"}{$parent} = \@node_data;
-              $node_index++; 
-        } 
-        for(my $i = 1; $i < $num_groups; $i++) {
-            $child_to_parents{$child}{"$child\_PSEUDONODE\_$i"} = [1,$child_to_parents{$child}{$parents[0]}[1]];
-        }
-    }
-}
-
-###output file
-
-my $number_of_interactions = 0;
-foreach my $child (keys %child_to_parents) {
-    $number_of_interactions += scalar( keys %{$child_to_parents{$child}});
-}
-
-say "$number_of_interactions\n";
-foreach my $child (keys %child_to_parents) {
-    foreach my $parent (keys %{$child_to_parents{$child}}) {
-        my @values = @{$child_to_parents{$child}{$parent}};
-        say "$parent\t$child\t".$values[0]."\t".$values[1];
-    }
-}
+create_pi_file($output_filepath, $interactions);

--- a/lib/perl/PGMLab.pm
+++ b/lib/perl/PGMLab.pm
@@ -6,9 +6,81 @@ use warnings;
 use autodie;
 use feature qw(say);
 
+use Data::Dumper;
+
 use base "Exporter";
 use vars qw(@EXPORT_OK);
-@EXPORT_OK = qw(create_obs_file);
+@EXPORT_OK = qw(is_pi_DAG create_pi_file create_obs_file get_nodes_in_pi_file get_interactions_in_pi_file get_siblings_in_pi_file);
+
+sub is_pi_DAG {
+    my($pi_interactions) = @_;
+
+    my %network;
+    foreach my $node (keys %{$pi_interactions}) {
+        if (defined $pi_interactions->{$node}) {
+             my @keys = keys %{$pi_interactions->{$node}};
+             my $children = \@keys;
+             if ($children) { #can't be in cycle if does not have children
+                 $network{$node} = {"children" => $children,
+                                    "visited"  => 0};
+             }
+        }
+    }
+
+    foreach my $node (keys %network) {
+        next if ($network{$node}{visited});
+        $network{$node}{visited} = $node;
+
+        my $start_node = $node;
+        my $resp = visit_children(\%network, $start_node, $node); 
+        return $resp if ($resp);
+    }
+
+    return 0;
+}
+
+sub visit_children {
+    my ($network, $start_node, $node) = @_;
+
+    foreach my $child (@{$network->{$node}{children}}) {
+         return 1 if (($network->{$child}{visited}) && ($network->{$child}{visited} eq $start_node)); 
+         $network->{$node}{visited} = $start_node if (not $network->{$child}{visited});
+         my $resp = visit_children($network, $start_node, $child); 
+         return $resp if($resp);
+    }
+
+    return 0;   
+}
+
+sub create_pi_file {
+    my ($pi_filepath, $interactions) = @_;
+
+    my $number_of_interactions = get_number_of_interactions($interactions);
+
+    open(my $fh, ">", $pi_filepath);
+
+    print $fh "$number_of_interactions\n\n";
+    foreach my $child (keys %{$interactions}) {
+        foreach my $parent (keys %{$interactions->{$child}}) {
+            my @values = @{$interactions->{$child}{$parent}};
+            print $fh "$parent\t$child\t".$values[0]."\t".$values[1]."\n";
+        }
+    }
+    
+    close($fh);
+}
+
+sub get_number_of_interactions {
+    my ($interactions) = @_;
+
+    my $number_of_interactions = 0;
+    foreach my $child (keys %{$interactions}) {
+        $number_of_interactions += scalar( keys %{$interactions->{$child}});
+    }
+
+    return $number_of_interactions;
+}
+
 
 sub create_obs_file {
     my ($obs_filepath, $sample_gene_states, $sample_list) = @_;
@@ -29,6 +101,70 @@ sub create_obs_file {
     }
 
     close($obs_fh);
+}
+
+
+sub get_interactions_in_pi_file {
+    my ($pi_file_path) = @_;
+
+    open(my $fh_pi, "<", $pi_file_path);
+
+    <$fh_pi>;<$fh_pi>; ##remove fist two rows
+
+    my %pi_interactions;
+    my ($from, $to, $column_3, $column_4);
+    while (my $interaction = <$fh_pi>) {
+        chomp $interaction;
+        ($from, $to, $column_3, $column_4) = split /\t/, $interaction;
+        $pi_interactions{$from}{$to} = [$column_3, $column_4];
+    }
+
+    close($fh_pi);
+
+    return \%pi_interactions;
+}
+
+sub get_nodes_in_pi_file {
+    my ($pi_file_path) = @_;
+
+    open(my $fh_pi, "<", $pi_file_path);
+
+    <$fh_pi>;<$fh_pi>; ##remove fist two rows
+
+    my %pi_nodes;
+    my ($from, $to, $column_3, $column_4);
+    while (my $interaction = <$fh_pi>) {
+        chomp $interaction;
+        ($from, $to, $column_3, $column_4) = split /\t/, $interaction;
+        $pi_nodes{$from} = 1;
+        $pi_nodes{$to} = 1;
+
+    }
+
+    close($fh_pi);
+
+    return \%pi_nodes;
+}
+
+sub get_siblings_in_pi_file {
+    my ($pi_filepath) = @_;
+
+    open(my $fh, "<", $pi_filepath);
+
+    #skip header
+    <$fh>;<$fh>;
+
+    my %siblings;
+    while (my $line = <$fh>) {
+        chomp $line;
+        my ($from, $to, $part_three, $part_four) = split /\t/, $line;
+        $siblings{$to}{siblings}{$from} = 1;
+        $siblings{$from}{siblings}{$to} = 1;
+    }
+
+    close $fh;
+
+    return \%siblings;
 }
 
 1;

--- a/lib/perl/PGMLab/Bio.pm
+++ b/lib/perl/PGMLab/Bio.pm
@@ -10,7 +10,7 @@ use Data::Dumper;
 
 use base "Exporter";
 use vars qw(@EXPORT_OK);
-@EXPORT_OK = qw(get_donor_ploidy get_reactome_ids_to_names_maps get_genes_in_pi_file get_sample_list get_copy_number_gene_states get_gistic_gene_states get_samples_from_sample_file get_snv_sample_gene_state);
+@EXPORT_OK = qw(get_donor_ploidy get_reactome_ids_to_names_maps get_sample_list get_copy_number_gene_states get_gistic_gene_states get_samples_from_sample_file get_snv_sample_gene_state);
 
 sub get_donor_ploidy {
     my ($ploidy_filepath) = @_; 
@@ -83,30 +83,6 @@ sub get_reactome_ids_to_names_maps {
 
     return (\%entity_name_to_reactome_id, \%reactome_id_to_entity_name);
 }
-
-sub get_genes_in_pi_file {
-    my ($pi_file_path) = @_;
-
-    open(my $fh_pi, "<", $pi_file_path);
-    
-    <$fh_pi>;<$fh_pi>; ##remove fist two rows
-    
-    my %pi_genes;
-    my ($from, $to, $column_3, $column_4);
-    while (my $interaction = <$fh_pi>) {
-        chomp $interaction;
-        ($from, $to, $column_3, $column_4) = split /\t/, $interaction;
-        $pi_genes{$from} = 1;
-        $pi_genes{$to} = 1;
-    
-    }
-    
-    my @pathway_genes = keys %pi_genes;
-    
-    close($fh_pi);
-
-    return \%pi_genes;
-}  
 
 sub getting_sample_list {
     my ($sample_list_path) = @_;   

--- a/lib/perl/PGMLab/NetworkComponents.pm
+++ b/lib/perl/PGMLab/NetworkComponents.pm
@@ -1,0 +1,50 @@
+package PGMLab::NetworkComponents;
+
+#This module is inspired by Daniel Larremore's MatLab moduel netowrkComponents
+
+use strict;
+use warnings;
+no warnings 'recursion';
+
+use autodie;
+
+use base "Exporter";
+use vars qw(@EXPORT_OK);
+@EXPORT_OK = qw(network_components);
+
+sub network_components {
+    my ($siblings) = @_; 
+
+    foreach my $node (keys %{$siblings}) {
+        $siblings->{$node}{visited} = 0;
+    }
+    
+    my @member_groups;
+    foreach my $node (keys %{$siblings}) {
+        next if ($siblings->{$node}{visited} == 1); 
+    
+        my @members = ();
+    
+        visit_siblings($siblings, \@members, $node);
+    
+        push @member_groups, \@members;
+    }
+
+    return \@member_groups;
+}
+
+sub visit_siblings {
+    my ($siblings, $members, $node) = @_;
+
+    return if ($siblings->{$node}{visited} == 1);
+    $siblings->{$node}{visited} = 1;
+    
+    push @{$members}, $node;
+
+    foreach my $sibling (keys %{$siblings->{$node}{siblings}}) {
+        visit_siblings($siblings, $members, $sibling);
+    }
+
+}
+
+1;

--- a/www/pgmlab/pgmlab_utils.py
+++ b/www/pgmlab/pgmlab_utils.py
@@ -26,7 +26,7 @@ def write_pairwise_interaction(run_path, pi_file):
 def split_pairwise_interaction(run_path):
     pi_filepath = run_path+"pathway.pi"
     pi_split_filepath = run_path+"pathway.split.pi"
-    command = "perl {0} {1} > {2}".format(split_nodes_path, pi_filepath, pi_split_filepath)
+    command = "perl {0} {1} {2}".format(split_nodes_path, pi_filepath, pi_split_filepath)
     return system_call(command)
 
 def write_observation(run_path, obs_file, run_type):


### PR DESCRIPTION
This pull request involves changes that allow us to process the pathways as given to us by Reactome. It will take in a folder of tsv pi files and output to another folder the resulting pi files. 

Features
1) Splits tsv pathway files into separate pi files based on connectedness.
2) Outputs whether or not it is a DAG.
3) Adds splits nodes that have greater than n parents with "pseudo" nodes.

@mdpham There is only one minor change that effects your part of the code. You might want to check that it works. 